### PR TITLE
Truncation bug when extra space is selected.

### DIFF
--- a/vendor/assets/javascripts/textile-editor.js
+++ b/vendor/assets/javascripts/textile-editor.js
@@ -274,7 +274,7 @@ TextileEditor.Methods = {
       // *Bold text *here => *Bold text*
       if (selectedText.match(/\s$/g)) {
         selectedText = selectedText.replace(/\s$/g,'');
-        followupText = ' ';
+        followupText = ' ' + followupText;
       }
       
       // no clue, i'm sure it made sense at the time i wrote it


### PR DESCRIPTION
Glad to see this project has finally been gemified– we've been using your textile editor for a couple of years now and its been really great. Thanks for making this contribution available to the open-source community. 

This is an attempt to fix a bug we've noticed in Mac browsers (specifically Chrome & Safari) which inadvertently truncates the highlighted text when the user has an extra space at the end of their selection. I noticed in your comments that this may be a product of an unrelated IE bug so I've tried to ensure that there are no unintended consequences to this solution.  

I'm not really sure how to test this with your current testing suite but please feel free to advise if you have any ideas. 

Thanks again! 
